### PR TITLE
fix: alias export LucideIcons

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,9 +4,10 @@ export * from '@tamagui/button'
 export * from '@tamagui/get-button-sized'
 export * from '@tamagui/core'
 export * from '@tamagui/config-base'
-export * from '@tamagui/lucide-icons'
 export * from '@tamagui/stacks'
 export * from '@tamagui/text'
+
+export * as LucideIcons from '@tamagui/lucide-icons'
 
 export {
     Text,


### PR DESCRIPTION
Should allow a less polluted scope of icons.