### PR TITLE
build: version 2.0.0 tagged

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcetoad/tamagui-react-native",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "A design system specific to React Native for Tamagui.",
   "types": "./types/index.d.ts",
   "main": "dist/cjs",


### PR DESCRIPTION
Major version jump since `config-base` is gone for `config`. It may be a drop in replacement, but not sure at this moment.