### PR TITLE
fix: missing tamagui config when using `Label` component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@tamagui/core": "^1.126.12",
         "@tamagui/font-inter": "^1.126.12",
         "@tamagui/get-button-sized": "^1.126.12",
+        "@tamagui/label": "^1.126.12",
         "@tamagui/lucide-icons": "^1.126.12",
         "@tamagui/radio-group": "^1.126.12",
         "@tamagui/scroll-view": "^1.126.12",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@tamagui/core": "^1.126.12",
     "@tamagui/font-inter": "^1.126.12",
     "@tamagui/get-button-sized": "^1.126.12",
+    "@tamagui/label": "^1.126.12",
     "@tamagui/lucide-icons": "^1.126.12",
     "@tamagui/radio-group": "^1.126.12",
     "@tamagui/scroll-view": "^1.126.12",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export * from '@tamagui/stacks'
 export * from '@tamagui/text'
 export * from '@tamagui/scroll-view'
 export * from '@tamagui/radio-group'
+export * from '@tamagui/label'
 
 export * as LucideIcons from '@tamagui/lucide-icons'
 


### PR DESCRIPTION
this doesn't work now

```
import { Label } from '@tamagui/label'
```